### PR TITLE
Add per eval caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ data/screenshots/
 data/questionnaires/
 data/layouts/
 data/
+eval_cache/


### PR DESCRIPTION
Adds caching on a per eval basis. Arguments to the eval function are hashed and used to pull prior results

Might need to adjust what is added to the hash function. Right now its everything and a bit unsure about the determinism of `args`, but seems like it works in simple tests