### PR TITLE
Reduce training time

### DIFF
--- a/oai_agents/agents/base_agent.py
+++ b/oai_agents/agents/base_agent.py
@@ -401,9 +401,9 @@ class OAITrainer(ABC):
         rew_per_layout_per_teamtype = {}
         rew_per_layout = {}
 
-        # To reduce evaluation time: instead of evaluating all players, we randomly select either two or three of player positions for evaluation
+        # To reduce evaluation time: instead of evaluating all players, we randomly select three of player positions for evaluation
         # This is outside of the for loop, meaning that each time we evaluate the same player positions across all layouts for a fair comparison
-        selected_p_indexes = random.sample(range(self.args.num_players), min(random.choice([2, 3]), self.args.num_players))
+        selected_p_indexes = random.sample(range(self.args.num_players), min(3, self.args.num_players))
 
         for _, env in enumerate(self.eval_envs): 
             rew_per_layout_per_teamtype[env.layout_name] = {

--- a/oai_agents/agents/base_agent.py
+++ b/oai_agents/agents/base_agent.py
@@ -401,7 +401,7 @@ class OAITrainer(ABC):
         rew_per_layout_per_teamtype = {}
         rew_per_layout = {}
 
-        # To reduce evaluattion time: instead of evaluating all players, we randomly select either two or three of player positions for evaluation
+        # To reduce evaluation time: instead of evaluating all players, we randomly select either two or three of player positions for evaluation
         # This is outside of the for loop, meaning that each time we evaluate the same player positions across all layouts for a fair comparison
         selected_p_indexes = random.sample(range(self.args.num_players), min(random.choice([2, 3]), self.args.num_players))
 

--- a/oai_agents/agents/rl.py
+++ b/oai_agents/agents/rl.py
@@ -263,11 +263,11 @@ class RLAgentTrainer(OAITrainer):
         mean_training_rew = np.mean([ep_info["r"] for ep_info in self.learning_agent.agent.ep_info_buffer])
         self.best_training_rew *= 0.98
 
-        steps_divisable_by_5 = (steps + 1) % 5 == 0
+        steps_divisable_by_15 = (steps + 1) % 15 == 0
         mean_rew_greater_than_best = mean_training_rew > self.best_training_rew and self.learning_agent.num_timesteps >= 5e6
         checkpoint_rate_reached = self.checkpoint_rate and self.learning_agent.num_timesteps // self.checkpoint_rate > (len(self.ck_list) - 1)
     
-        return steps_divisable_by_5 or mean_rew_greater_than_best or checkpoint_rate_reached
+        return steps_divisable_by_15 or mean_rew_greater_than_best or checkpoint_rate_reached
 
     def log_details(self, experiment_name, total_train_timesteps):
         print("Training agent: " + self.name + ", for experiment: " + experiment_name)

--- a/scripts/train_agents.py
+++ b/scripts/train_agents.py
@@ -399,10 +399,12 @@ if __name__ == '__main__':
     args.adversary_force_training = True
     args.primary_force_training = True
 
-    args.teammates_len = 3
+    args.teammates_len = 2
     args.how_long = 6 # not effective when quick_test is True
 
     set_input(args=args)
+
+    SPN_1ADV_XSPCKP(args=args)
 
     # SP(args)
 
@@ -415,7 +417,5 @@ if __name__ == '__main__':
     # SPN_1ADV(args=args)
 
     # SPN_XSPCKP(args=args)
-
-    SPN_1ADV_XSPCKP(args=args)
 
     # N_1_FCP(args=args)


### PR DESCRIPTION
This PR reduces our training time by relaxing the way we evaluate our agents: [link](https://github.com/HIRO-group/multiHRI/blob/2552629130f9cb672678747a6492a076221cdd7c/oai_agents/agents/base_agent.py#L426)

Previously, agents were evaluated in every possible position, which increased training time as the number of agents grew. For example, for a 3-player layout the agent was evaluated in three different positions, while for a 5-player layout the agent was evaluated in five different positions. Since evaluation is expensive, this causes our training time to increase as number of agents increases. In this PR I relaxed this condition by only evaluating each agent in only 2 or 3 randomly selected positions rather than in all possible positions. 