### PR TITLE
Create the wandb dir if it doesnt exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ data/questionnaires/
 data/layouts/
 data/
 eval_cache/
+wandb/

--- a/oai_agents/agents/il.py
+++ b/oai_agents/agents/il.py
@@ -18,6 +18,7 @@ from torch.utils.data import DataLoader, random_split
 from torch.distributions.categorical import Categorical
 from typing import Dict, Any, Union
 import wandb
+import os
 
 
 class BehaviouralCloningPolicy(nn.Module):
@@ -189,6 +190,7 @@ class BehavioralCloningTrainer(OAITrainer):
         if self.datasets is None:
             self.setup_datasets()
         exp_name = exp_name or self.args.exp_name
+        os.makedirs(str(self.args.base_dir / 'wandb'), exist_ok=True)
         run = wandb.init(project="overcooked_ai", entity=self.args.wandb_ent,
                          dir=str(self.args.base_dir / 'wandb'),
                          reinit=True, name=exp_name + '_' + self.name, mode=self.args.wandb_mode)

--- a/oai_agents/agents/rl.py
+++ b/oai_agents/agents/rl.py
@@ -294,6 +294,7 @@ class RLAgentTrainer(OAITrainer):
 
     def train_agents(self, total_train_timesteps, tag_for_returning_agent, exp_name=None, resume_ck_list=None):
         experiment_name = self.get_experiment_name(exp_name)
+        os.makedirs(str(self.args.base_dir / 'wandb'), exist_ok=True)
         run = wandb.init(project="overcooked_ai", entity=self.args.wandb_ent, dir=str(self.args.base_dir / 'wandb'),
                          reinit=True, name=experiment_name, mode=self.args.wandb_mode,
                          resume="allow")


### PR DESCRIPTION
Creates the wandb dir if it doesnt exist, should avoid the single owner /tmp dir problem